### PR TITLE
chore: better import.

### DIFF
--- a/react/client/src/App.js
+++ b/react/client/src/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import circuitBreaker from 'opossum/dist/opossum';
+import circuitBreaker from 'opossum';
 import $ from 'jquery';
 
 class App extends Component {


### PR DESCRIPTION
* this updates the import statement to just import 'opossum' instead of the dist.

Now that we've removed prometheus from the opossum library, we can go back to importing just `opossum` instead of the dist directory