### PR TITLE
Update examples to use opossum 4.2.1

### DIFF
--- a/angular5/package-lock.json
+++ b/angular5/package-lock.json
@@ -7322,9 +7322,9 @@
       }
     },
     "opossum": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/opossum/-/opossum-4.0.0.tgz",
-      "integrity": "sha512-T9w/cxhT5Q3WcaU6m3BE9csDzyojC1+NniMqJipTeqiUKU4h3DdZqZubKgekpMD507dXUAzNASwD33VVRtJP4A=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/opossum/-/opossum-4.2.1.tgz",
+      "integrity": "sha512-V0xLXTM24JhjvS+LP+2yT7CYEKiNo3zuvMaxsJrDeAIwGNmGuNZrqcAfIiRmFWdGGpA0HpybXOLQ2OOaAI3ATQ=="
     },
     "optimist": {
       "version": "0.6.1",

--- a/angular5/package.json
+++ b/angular5/package.json
@@ -30,7 +30,7 @@
     "@hapi/hoek": "8.2.0",
     "https-proxy-agent": "2.2.2",
     "@hapi/inert": "5.2.1",
-    "opossum": "4.0.0",
+    "opossum": "4.2.1",
     "rxjs": "6.5.2",
     "rxjs-compat": "6.5.2",
     "sass": "1.22.9",

--- a/ember/client/package-lock.json
+++ b/ember/client/package-lock.json
@@ -11885,9 +11885,9 @@
       }
     },
     "opossum": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/opossum/-/opossum-4.0.0.tgz",
-      "integrity": "sha512-T9w/cxhT5Q3WcaU6m3BE9csDzyojC1+NniMqJipTeqiUKU4h3DdZqZubKgekpMD507dXUAzNASwD33VVRtJP4A==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/opossum/-/opossum-4.2.1.tgz",
+      "integrity": "sha512-V0xLXTM24JhjvS+LP+2yT7CYEKiNo3zuvMaxsJrDeAIwGNmGuNZrqcAfIiRmFWdGGpA0HpybXOLQ2OOaAI3ATQ==",
       "dev": true
     },
     "optimist": {

--- a/ember/client/package.json
+++ b/ember/client/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-ember": "^6.2.0",
     "eslint-plugin-node": "^9.0.1",
     "loader.js": "^4.7.0",
-    "opossum": "~4.0.0",
+    "opossum": "~4.2.1",
     "qunit-dom": "^0.8.4"
   },
   "engines": {

--- a/hystrix/package-lock.json
+++ b/hystrix/package-lock.json
@@ -287,9 +287,9 @@
       }
     },
     "opossum": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/opossum/-/opossum-4.0.0.tgz",
-      "integrity": "sha512-T9w/cxhT5Q3WcaU6m3BE9csDzyojC1+NniMqJipTeqiUKU4h3DdZqZubKgekpMD507dXUAzNASwD33VVRtJP4A=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/opossum/-/opossum-4.2.1.tgz",
+      "integrity": "sha512-V0xLXTM24JhjvS+LP+2yT7CYEKiNo3zuvMaxsJrDeAIwGNmGuNZrqcAfIiRmFWdGGpA0HpybXOLQ2OOaAI3ATQ=="
     },
     "opossum-hystrix": {
       "version": "0.0.1",

--- a/hystrix/package.json
+++ b/hystrix/package.json
@@ -9,7 +9,7 @@
     "body-parser": "^1.18.3",
     "debug": "~4.1.1",
     "express": "^4.16.4",
-    "opossum": "~4.0.0",
+    "opossum": "~4.2.1",
     "opossum-hystrix": "0.0.1"
   }
 }

--- a/jquery/package-lock.json
+++ b/jquery/package-lock.json
@@ -1036,9 +1036,9 @@
       }
     },
     "opossum": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/opossum/-/opossum-4.0.0.tgz",
-      "integrity": "sha512-T9w/cxhT5Q3WcaU6m3BE9csDzyojC1+NniMqJipTeqiUKU4h3DdZqZubKgekpMD507dXUAzNASwD33VVRtJP4A=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/opossum/-/opossum-4.2.1.tgz",
+      "integrity": "sha512-V0xLXTM24JhjvS+LP+2yT7CYEKiNo3zuvMaxsJrDeAIwGNmGuNZrqcAfIiRmFWdGGpA0HpybXOLQ2OOaAI3ATQ=="
     },
     "optionator": {
       "version": "0.8.2",

--- a/jquery/package.json
+++ b/jquery/package.json
@@ -25,7 +25,7 @@
     "@hapi/hapi": "18.3.1",
     "@hapi/inert": "5.2.1",
     "jquery": "3.4.1",
-    "opossum": "4.0.0"
+    "opossum": "4.2.1"
   },
   "bugs": {
     "url": "https://github.com/nodeshift/opossum/issues"

--- a/prometheus/package-lock.json
+++ b/prometheus/package-lock.json
@@ -1843,9 +1843,9 @@
       }
     },
     "opossum": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/opossum/-/opossum-4.0.0.tgz",
-      "integrity": "sha512-T9w/cxhT5Q3WcaU6m3BE9csDzyojC1+NniMqJipTeqiUKU4h3DdZqZubKgekpMD507dXUAzNASwD33VVRtJP4A=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/opossum/-/opossum-4.2.1.tgz",
+      "integrity": "sha512-V0xLXTM24JhjvS+LP+2yT7CYEKiNo3zuvMaxsJrDeAIwGNmGuNZrqcAfIiRmFWdGGpA0HpybXOLQ2OOaAI3ATQ=="
     },
     "opossum-prometheus": {
       "version": "0.0.2",

--- a/prometheus/package.json
+++ b/prometheus/package.json
@@ -16,7 +16,7 @@
     "express": "^4.16.4",
     "kube-probe": "~0.3.2",
     "nodemon": "^1.18.10",
-    "opossum": "4.0.0",
+    "opossum": "4.2.1",
     "opossum-prometheus": "0.0.2"
   }
 }

--- a/react/client/package-lock.json
+++ b/react/client/package-lock.json
@@ -8837,9 +8837,9 @@
       }
     },
     "opossum": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/opossum/-/opossum-4.0.0.tgz",
-      "integrity": "sha512-T9w/cxhT5Q3WcaU6m3BE9csDzyojC1+NniMqJipTeqiUKU4h3DdZqZubKgekpMD507dXUAzNASwD33VVRtJP4A=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/opossum/-/opossum-4.2.1.tgz",
+      "integrity": "sha512-V0xLXTM24JhjvS+LP+2yT7CYEKiNo3zuvMaxsJrDeAIwGNmGuNZrqcAfIiRmFWdGGpA0HpybXOLQ2OOaAI3ATQ=="
     },
     "optimist": {
       "version": "0.6.1",

--- a/react/client/package.json
+++ b/react/client/package.json
@@ -6,7 +6,7 @@
     "browserify": "16.3.0",
     "jquery": "3.4.1",
     "literalify": "0.4.0",
-    "opossum": "4.0.0",
+    "opossum": "4.2.1",
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "react-scripts": "3.0.1"

--- a/seneca/package-lock.json
+++ b/seneca/package-lock.json
@@ -2018,9 +2018,9 @@
       }
     },
     "opossum": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/opossum/-/opossum-4.0.0.tgz",
-      "integrity": "sha512-T9w/cxhT5Q3WcaU6m3BE9csDzyojC1+NniMqJipTeqiUKU4h3DdZqZubKgekpMD507dXUAzNASwD33VVRtJP4A=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/opossum/-/opossum-4.2.1.tgz",
+      "integrity": "sha512-V0xLXTM24JhjvS+LP+2yT7CYEKiNo3zuvMaxsJrDeAIwGNmGuNZrqcAfIiRmFWdGGpA0HpybXOLQ2OOaAI3ATQ=="
     },
     "optimist": {
       "version": "0.6.1",

--- a/seneca/package.json
+++ b/seneca/package.json
@@ -26,7 +26,7 @@
     "@hapi/inert": "5.2.1",
     "jquery": "3.4.1",
     "lodash": "4.17.15",
-    "opossum": "4.0.0",
+    "opossum": "4.2.1",
     "seneca": "3.13.0"
   },
   "bugs": {


### PR DESCRIPTION
jQuery and React examples are tested with the updated opossum version. The rest examples should be working as expected.