### PR TITLE
chore: add node type in config to fix building

### DIFF
--- a/angular5/tsconfig.app.json
+++ b/angular5/tsconfig.app.json
@@ -2,7 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/app",
-    "types": []
+    "types": [
+      "node"
+    ]
   },
   "files": [
     "src/main.ts",


### PR DESCRIPTION
@alexalikiotis i did a quick google and this atleast fixed things so i could run `npm run build`