### PR TITLE
Adding "multiple-express" example

### DIFF
--- a/more-examples/multiple-express/README.md
+++ b/more-examples/multiple-express/README.md
@@ -1,0 +1,51 @@
+# Opossum Multiple-Express Example
+
+This example uses multiple express.js servers and a client to perform the requests. The opossum module is present only to the last express.js server in the chain.
+
+### Architecture
+client -> express (middleman) -> express (end)
+
+### Steps
+
+```sh
+$ npm install
+$ npm start
+```
+
+Open a new terminal and run:
+
+```sh
+$ npm test
+```
+
+Result: 
+
+```
+success: 153
+
+success: 154
+
+failures: 27, fallbacks: 0, rejects: 0, timeouts: 0
+
+failures: 28, fallbacks: 0, rejects: 0, timeouts: 0
+
+success: 155
+
+success: 156
+
+success: 157
+
+success: 158
+
+success: 159
+
+success: 160
+
+success: 161
+
+failures: 29, fallbacks: 0, rejects: 0, timeouts: 0
+
+...
+```
+
+This example is based on this use case: https://github.com/nodeshift/opossum/issues/181

--- a/more-examples/multiple-express/benchmark/index.js
+++ b/more-examples/multiple-express/benchmark/index.js
@@ -1,0 +1,6 @@
+const lowCarb = require('lowcarb');
+
+const client = require('../client');
+
+lowCarb.add(client.makeRequest, 100);
+lowCarb.run('', false, true);

--- a/more-examples/multiple-express/client.js
+++ b/more-examples/multiple-express/client.js
@@ -1,0 +1,26 @@
+const http = require('http');
+
+const options = {
+  hostname: '127.0.0.1',
+  port: 8080,
+  path: '/',
+  method: 'GET',
+};
+
+const makeRequest = () => {
+  const request = http.request(options, response => {
+    response.on('data', data => {
+      console.log(data.toString());
+    });
+  });
+
+  request.on('error', error => {
+    console.error(error);
+  });
+
+  request.end();
+};
+
+module.exports = {
+  makeRequest,
+};

--- a/more-examples/multiple-express/express-end.js
+++ b/more-examples/multiple-express/express-end.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const CircuitBreaker = require('opossum');
+
+const randomFailure = (echo) => {
+  return Date.now() % 5 === 0 ? Promise.reject("\n") : Promise.resolve(echo);
+};
+
+const options = {};
+const breaker = new CircuitBreaker(randomFailure, options);
+const app = express();
+
+app.get('/', (req, res) => {
+  breaker.fire('\n')
+    .then((result) => {
+      result += `success: ${breaker.stats.successes}`;
+      res.send(result);
+    })
+    .catch((err) => {
+      const { failures, fallbacks, rejects, timeouts } = breaker.stats;
+      err += `failures: ${failures}, fallbacks: ${fallbacks}, rejects: ${rejects}, timeouts: ${timeouts}`;
+      res.send(err);
+    });
+});
+
+app.listen(3000);

--- a/more-examples/multiple-express/express-middleman.js
+++ b/more-examples/multiple-express/express-middleman.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const axios = require('axios').default;
+
+const app = express();
+
+app.get('/', (req, res) => {
+  axios.get('http://localhost:3000')
+    .then(result => res.send(result.data))
+    .catch(err => res.send(err));
+});
+
+app.listen(8080);

--- a/more-examples/multiple-express/package.json
+++ b/more-examples/multiple-express/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "multiple-express",
+  "version": "1.0.0",
+  "description": "",
+  "main": "client.js",
+  "scripts": {
+    "start": "concurrently \"node express-end.js\" \"node express-middleman.js\"",
+    "test": "node benchmark/index.js"
+  },
+  "dependencies": {
+    "axios": "^0.19.2",
+    "express": "^4.17.1",
+    "opossum": "^5.0.0"
+  },
+  "devDependencies": {
+    "concurrently": "^5.2.0",
+    "lowcarb": "^0.5.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
This example is from opossum-playground repository.
We can keep this as an example and discard the "two-express"
example in opossum-playground.